### PR TITLE
Better handle audio and video conversion

### DIFF
--- a/scripts/extract_media.mjs
+++ b/scripts/extract_media.mjs
@@ -38,6 +38,12 @@ export function extract_video(tempdir, jpsxdec_jar, no_delete) {
                 join(tempdir, movieDir, file),
                 "-pix_fmt",
                 "yuv420p",
+                "-preset",
+                "veryslow",
+                "-level",
+                "31",
+                "-ar",
+                "44100",
                 join(OUTPUT_MOVIE_FOLDER, file.replace("avi", "mp4")),
             ]);
         }
@@ -73,6 +79,8 @@ export function extract_audio(tempdir, jpsxdec_jar, no_delete) {
         try_spawn_process("ffmpeg", [
             "-i",
             join(tempdir, "XA", file),
+            "-ar",
+            "44100",
             join(OUTPUT_AUDIO_FOLDER, file.replace("wav", "mp4")),
         ]);
     }


### PR DESCRIPTION
Those are the changes made and the reasons:
avi:rgb => avi:jyuv: as the documentations says "This is most similar to the original PlayStation video colors"
add zscale: the PSX video are in a particular color space (full range, bt601, centered chroma location), but modern browser, AFAIK, will use the "full HD colorspace" (limited range, bt709, left chroma location), making this conversion at the encoding stage will make sure that browser will display correct colors and levels
w=582:h=448: upscale the video and fix AR, i'm not quite sure regarding the AR, i've tested it counting pixel from duckstation on a couple of videos
-crf 15: a bit of a quality boost, the videos are quite small anyway, it can be raised to lower quality/size
-preset veryslow: quality boost at the expense of time, the video are short and at low resolution/framerate, it will take not much more
-level 31: force H264 level to 3.1 to allow better compatibility
-ar 44100: with default conversion ffmpeg was downsampling the 18.9KHz sound to 16KHz, also AAC use an internal lowpass filter so it was muffling the sound, this will upsample to 44.1KHz so that it will sound correctly
-b:a 192k: a bit more bitrate for the sound, it can probably be lowered to 128k but i prefer a bit more as the original sounds are already quite compressed

Regarding the videos a better job could be made introducing avs/vs in the mix, the original videos suffers quite a bit of blocking and Deblock_QED fix almost all of it with minimal/low loss of quality, also the upscale can be done using better algorithms like nnedi3 or a specifically trained ESRGAN model